### PR TITLE
fix(users): await user operations and fetch from Supabase in System Settings

### DIFF
--- a/src/components/SystemSettings.tsx
+++ b/src/components/SystemSettings.tsx
@@ -68,7 +68,8 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onClose }) => {
   }, [])
 
   const loadData = async () => {
-    setUsers(authService.getUsers())
+    const fetchedUsers = await authService.fetchUsers()
+    setUsers(fetchedUsers.length ? fetchedUsers : authService.getUsers())
     setPermissions(authService.getPermissions())
 
     try {
@@ -113,7 +114,7 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onClose }) => {
     }
 
     setLoading(true)
-    const result = authService.addUser({
+    const result = await authService.addUser({
       username: newUser.username,
       email: newUser.email,
       role: newUser.role,
@@ -138,7 +139,7 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onClose }) => {
     if (!editingUser) return
 
     setLoading(true)
-    const result = authService.updateUser(editingUser)
+    const result = await authService.updateUser(editingUser)
 
     if (result.success) {
       setSuccess('تم تحديث المستخدم بنجاح')
@@ -167,7 +168,7 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onClose }) => {
     }
 
     setLoading(true)
-    const result = authService.updatePassword(username, passwordForm.newPassword)
+    const result = await authService.updatePassword(username, passwordForm.newPassword)
 
     if (result.success) {
       setSuccess('تم تحديث كلمة المرور بنجاح')
@@ -183,7 +184,7 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onClose }) => {
     if (!window.confirm('هل أنت متأكد من حذف هذا المستخدم؟')) return
 
     setLoading(true)
-    const result = authService.deleteUser(userId)
+    const result = await authService.deleteUser(userId)
 
     if (result.success) {
       setSuccess('تم حذف المستخدم بنجاح')

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -160,14 +160,17 @@ class AuthService {
     }
   }
 
-  async fetchUsers(): Promise<User[]> {
-    if (!supabaseClient) return this.getUsers()
-    const { data, error } = await supabaseClient.from('users').select('*').order('created_at', { ascending: false })
-    if (error || !data) return []
-    const users = (data as unknown as UserRow[]).map(mapRowToUser)
-    localStorage.setItem(this.USERS_KEY, JSON.stringify(users))
-    return users
-  }
+  
+async fetchUsers(): Promise<User[]> {
+  if (!supabaseClient) return this.getUsers()
+  const { data, error } = await supabaseClient.from('users').select('*')
+  if (error || !data) return []
+  const rows = data as unknown as UserRow[]
+  rows.sort((a, b) => new Date(b.created_at || '').getTime() - new Date(a.created_at || '').getTime())
+  const users = rows.map(mapRowToUser)
+  localStorage.setItem(this.USERS_KEY, JSON.stringify(users))
+  return users
+}
 
   getPasswords(): Record<string, string> {
     try {


### PR DESCRIPTION
Summary
- Fix user management UI so it correctly reflects operation results and loads users from Supabase
- Root cause: promises from add/update/delete/password were not awaited in SystemSettings; UI mis-reported errors despite DB succeeding
- Now SystemSettings:
  - loadData uses authService.fetchUsers() then falls back to local cache
  - handleAddUser/handleUpdateUser/handleUpdatePassword/handleDeleteUser all await service calls
- authService.fetchUsers no longer relies on server-side ordering by created_at (avoids errors if column missing); sorts locally if present

Why this change
- Users were being added/removed in Supabase, but UI showed error messages and list did not refresh
- Ensures consistent UX and correct state after operations

Notes
- For production, consider migrating to Supabase Auth and removing plaintext password field
- Ensure RLS policies permit select/insert/update/delete according to your environment

Co-authored-by: openhands <openhands@all-hands.dev>

@drabtonman-ship-it can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4efd696041b14504ba284ab9e2c9e479)