### PR TITLE
feat: pricing and installation read only from Supabase + add CSV templates

### DIFF
--- a/supabase_csv/installation_pricing.csv
+++ b/supabase_csv/installation_pricing.csv
@@ -1,0 +1,1 @@
+id,zone_name,billboard_size,price,multiplier,currency,description,created_at

--- a/supabase_csv/pricing.csv
+++ b/supabase_csv/pricing.csv
@@ -1,0 +1,1 @@
+id,zone_id,zone_name,billboard_size,customer_type,price,ab_type,package_duration,package_discount,currency,created_at

--- a/supabase_csv/users.csv
+++ b/supabase_csv/users.csv
@@ -1,0 +1,1 @@
+id,username,email,role,permissions,assigned_client,pricing_category,is_active,created_at,password


### PR DESCRIPTION
Summary
- Remove demo/default fallbacks from pricing and installation pricing services
- Pricing now hydrates only from Supabase cloud (table: pricing); no JSON/KV/demo seeding
- Installation pricing now hydrates only from Supabase (table: installation_pricing); no JSON/defaults
- Save operations persist to Supabase only (cloudDatabase), not KV/JSON
- Add CSV templates for Supabase import under supabase_csv/
  - supabase_csv/pricing.csv
  - supabase_csv/installation_pricing.csv
  - supabase_csv/users.csv

Details
- newPricingService.ts: clear local demo data, hydrate via cloudDatabase.getRentalPricing; save uses cloud only
- pricingService.ts: drop dynamic/json fallbacks, rely on Supabase; simplify getPricing()
- installationPricingService.ts: clear local demo data, hydrate via cloudDatabase.getInstallationPricing; remove base default fallbacks
- cloudDatabase.ts: force Supabase for read/write (returns null/false when Supabase not configured)

CSV templates
- pricing.csv headers: id,zone_id,zone_name,billboard_size,customer_type,price,ab_type,package_duration,package_discount,currency,created_at
- installation_pricing.csv headers: id,zone_name,billboard_size,price,multiplier,currency,description,created_at
- users.csv headers: id,username,email,role,permissions,assigned_client,pricing_category,is_active,created_at,password

Migration notes
- Ensure both tables exist with matching columns; import data via the provided CSVs in Supabase Table Editor
- RLS must permit select/insert/update for your environment (anon for dev or authenticated for prod)

Co-authored-by: openhands <openhands@all-hands.dev>

@drabtonman-ship-it can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4efd696041b14504ba284ab9e2c9e479)