### PR TITLE
fix(build): async init IIFE syntax for Vite/esbuild compatibility

### DIFF
--- a/src/services/installationPricingService.ts
+++ b/src/services/installationPricingService.ts
@@ -67,7 +67,7 @@ class InstallationPricingService {
 private initializeDefaults() {
   // Clear any local/demo installation pricing; hydrate only from Supabase
   try { localStorage.removeItem(this.STORAGE_KEY) } catch {}
-  void (async () => {
+  ;(async () => {
     const remote = await cloudDatabase.getInstallationPricing()
     if (remote) {
       localStorage.setItem(this.STORAGE_KEY, JSON.stringify(remote))
@@ -76,7 +76,7 @@ private initializeDefaults() {
 }
 
     // Hydrate from cloud (Netlify KV) asynchronously
-    void (async () => {
+    ;(async () => {
       const remote = await cloudDatabase.getInstallationPricing()
       if (remote) {
         // استبدال أي بيانات تجريبية ببيانات القاعدة

--- a/src/services/newPricingService.ts
+++ b/src/services/newPricingService.ts
@@ -132,7 +132,7 @@ private initializeDefaults() {
   if (!localStorage.getItem(this.SIZES_STORAGE_KEY)) {
     localStorage.setItem(this.SIZES_STORAGE_KEY, JSON.stringify(DEFAULT_SIZES))
   }
-  void (async () => {
+  ;(async () => {
     try {
       const remote = await cloudDatabase.getRentalPricing()
       if (remote) {
@@ -143,7 +143,7 @@ private initializeDefaults() {
 }
 
     // Try hydrate from cloud asynchronously
-    void (async () => {
+    ;(async () => {
       try {
         const remote = await cloudDatabase.getRentalPricing()
         if (remote) {

--- a/src/services/pricingService.ts
+++ b/src/services/pricingService.ts
@@ -20,7 +20,7 @@ class PricingService {
 private initializePricingFromDB() {
   // Clear any local/demo data; hydrate only from Supabase
   try { localStorage.removeItem(this.PRICING_STORAGE_KEY) } catch {}
-  void (async () => {
+  ;(async () => {
     try {
       const remote = await cloudDatabase.getRentalPricing()
       if (remote) {
@@ -31,7 +31,7 @@ private initializePricingFromDB() {
 }
 
     // محاولة التحميل من قاعدة بيانات Supabase / السحابة
-    void (async () => {
+    ;(async () => {
       try {
         const remote = await cloudDatabase.getRentalPricing()
         if (remote) {


### PR DESCRIPTION
Summary
- Replace `void (async () => { ... })()` with `;(async () => { ... })()` in services
- Files: pricingService.ts, newPricingService.ts, installationPricingService.ts
- Reason: some environments/esbuild targets parse `void (async () => ...)()` incorrectly, causing `Expected ")" but found "("`

Impact
- Fixes `npm run dev` startup errors and allows scanning/building
- No behavior change in logic; only IIFE invocation syntax has been adjusted

Related PRs
- #4: enforce Supabase-only pricing and installation + CSV templates

Co-authored-by: openhands <openhands@all-hands.dev>

@drabtonman-ship-it can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4efd696041b14504ba284ab9e2c9e479)